### PR TITLE
convert epoch to milliseconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func helmStats(w http.ResponseWriter, r *http.Request) {
 			releaseName := item.GetName()
 			version := item.GetChart().GetMetadata().GetVersion()
 			appVersion := item.GetChart().GetMetadata().GetAppVersion()
-			updated := strconv.FormatInt(item.GetInfo().GetLastDeployed().Seconds, 10)
+			updated := strconv.FormatInt((item.GetInfo().GetLastDeployed().Seconds * 1000), 10)
 			namespace := item.GetNamespace()
 			if status == release.Status_FAILED {
 				status = -1


### PR DESCRIPTION
This just multiplies the Seconds by 1000, to ensure Grafana can format the epoch label properly with this https://github.com/grafana/grafana/pull/14510 which assumes the epoch is in milliseconds.