### PR TITLE
Add option to set the value to helm release's timestamp

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the helm-exporter chart
 | image.pullPolicy | string | `"Always"` | Image pull policy for the webhook integration jobs |
 | image.repository | string | `"sstarcher/helm-exporter"` | Repository to use for the webhook integration jobs |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images |
+| infoMetric | bool | `true` | Specifies whether to generate the info metric. |
 | ingress.annotations | object | `{}` |  Annotations for the helm-exporter |
 | ingress.enabled | bool | `false` | If true, helm-exporter Ingress will be created |
 | ingress.hosts[0].host | string | `"chart-example.local"` | Ingress hostname |
@@ -72,7 +73,7 @@ The following table lists the configurable parameters of the helm-exporter chart
 | serviceMonitor.namespace | string | `nil` | The namespace where the Prometheus Operator is deployed |
 | serviceMonitor.additionalLabels |object | `{}` | Additional labels to add to the ServiceMonitor	|
 | serviceMonitor.scrapeTimeout | string | `nil` | Scrape Timeout when the metrics endpoint is scraped |
-| timestamp | bool | `false` | Specifies whether to set value to helm release's timestamp. |
+| timestampMetric | bool | `true` | Specifies whether to generate the timestamps metric. |
 | tolerations | list | `[]` | Tolerations for use with node taints [https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)|
 
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the helm-exporter chart
 | serviceMonitor.namespace | string | `nil` | The namespace where the Prometheus Operator is deployed |
 | serviceMonitor.additionalLabels |object | `{}` | Additional labels to add to the ServiceMonitor	|
 | serviceMonitor.scrapeTimeout | string | `nil` | Scrape Timeout when the metrics endpoint is scraped |
+| timestamp | bool | `false` | Specifies whether to set value to helm release's timestamp. |
 | tolerations | list | `[]` | Tolerations for use with node taints [https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)|
 
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,10 +48,11 @@ spec:
             - "-namespaces"
             - {{ .Values.namespaces | quote }}
             {{- end }}
-            {{- if .Values.timestamp }}
-            - "-timestamp=true"
-            {{- else }}
-            - "-timestamp=false"
+            {{- if not .Values.infoMetric }}
+            - "-info-metric=false"
+            {{- end }}
+            {{- if not .Values.timestampMetric }}
+            - "-timestamp-metric=false"
             {{- end }}
           ports:
             - name: http

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,9 +43,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.namespaces }}
-          args: ["-namespaces", {{ .Values.namespaces | quote }}]
-          {{- end }}
+          args:
+            {{- if .Values.namespaces }}
+            - "-namespaces"
+            - {{ .Values.namespaces | quote }}
+            {{- end }}
+            {{- if .Values.timestamp }}
+            - "-timestamp=true"
+            {{- else }}
+            - "-timestamp=false"
+            {{- end }}
           ports:
             - name: http
               containerPort: 9571

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,7 @@
 # Specifies which namespaces to query for helm 3 metrics.  Defaults to all
 namespaces: ""
-timestamp: false
+infoMetric: true
+timestampMetric: true
 
 serviceMonitor:
   # Specifies whether a ServiceMonitor should be created

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,6 @@
 # Specifies which namespaces to query for helm 3 metrics.  Defaults to all
 namespaces: ""
+timestamp: false
 
 serviceMonitor:
   # Specifies whether a ServiceMonitor should be created

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 
 	namespaces = flag.String("namespaces", "", "namespaces to monitor.  Defaults to all")
 	configFile = flag.String("config", "", "Configfile to load for helm overwrite registries.  Default is empty")
+	timestamp  = flag.Bool("timestamp", false, "Set value to timestamp.  Defaults to false")
 
 	statusCodeMap = map[string]float64{
 		"unknown":          0,
@@ -88,12 +89,17 @@ func runStats(config config.Config) {
 			releaseName := item.Name
 			version := item.Chart.Metadata.Version
 			appVersion := item.Chart.AppVersion()
-			updated := strconv.FormatInt((item.Info.LastDeployed.Unix() * 1000), 10)
+			updated := item.Info.LastDeployed.Unix() * 1000
 			namespace := item.Namespace
 			status := statusCodeMap[item.Info.Status.String()]
 			latestVersion := getLatestChartVersionFromHelm(item.Chart.Name(), config.HelmRegistries)
 			//latestVersion := "3.1.8"
-			stats.WithLabelValues(chart, releaseName, version, appVersion, updated, namespace, latestVersion).Set(status)
+
+			if *timestamp == false {
+				stats.WithLabelValues(chart, releaseName, version, appVersion, strconv.FormatInt(updated, 10), namespace, latestVersion).Set(status)
+			} else {
+				stats.WithLabelValues(chart, releaseName, version, appVersion, strconv.FormatInt(updated, 10), namespace, latestVersion).Set(float64(updated))
+			}
 		}
 	}
 }


### PR DESCRIPTION
Recent versions of Grafana (I am testing with v6.7.1) have a "Series value as timestamp" option which can be used with the timestamp option implemented in this PR, in order to use the helm_chart_info metric for Grafana annotations pulled from Prometheus.

https://grafana.com/docs/grafana/latest/reference/annotations/#querying-other-data-sources

![2020-05-16-022125_1270x940_scrot](https://user-images.githubusercontent.com/5933427/82103547-1aa32780-971c-11ea-9c9f-3c26870b33d7.png)
