### PR TITLE
Fix the ConfigMap template's indentation

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
     name: {{ include "helm-exporter.fullname" . }}
     labels:
-        {{ include "helm-exporter.labels" . | nindent 4 }}
+        {{ include "helm-exporter.labels" . | nindent 8 }}
 data:
     config.yaml: |-
 {{ toYaml .Values.config | indent 6}}


### PR DESCRIPTION
The helm chart cannot be applied without this PR due to wrong indentation of labels in the ConfigMap template.