### PR TITLE
Make fetching the latest chart version configurable

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the helm-exporter chart
 | ingress.hosts[0].host | string | `"chart-example.local"` | Ingress hostname |
 | ingress.hosts[0].paths | list | `[]` | Ingress paths |
 | ingress.tls | list | `[]` | Ingress TLS configuration (YAML) |
+| latestChartVersion | bool | `true` | Specifies whether to fetch the latest chart versions from repositories. |
 | nameOverride | string | `""` | Provide a name in place of helm-exporter |
 | namespaces | string | `""` | Specifies which namespaces to query for helm 3 metrics.  Defaults to all |
 | nodeSelector | object | `{}` | helm-exporter node selector [https://kubernetes.io/docs/user-guide/node-selection/](https://kubernetes.io/docs/user-guide/node-selection/ ) |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             {{- if not .Values.timestampMetric }}
             - "-timestamp-metric=false"
             {{- end }}
+            {{- if not .Values.latestChartVersion }}
+            - "-latest-chart-version=false"
+            {{- end }}
           ports:
             - name: http
               containerPort: 9571

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@
 namespaces: ""
 infoMetric: true
 timestampMetric: true
+latestChartVersion: true
 
 serviceMonitor:
   # Specifies whether a ServiceMonitor should be created

--- a/main.go
+++ b/main.go
@@ -119,7 +119,6 @@ func runStats(config config.Config) {
 
 			if *fetchLatest {
 				latestVersion = getLatestChartVersionFromHelm(item.Chart.Name(), config.HelmRegistries)
-				//latestVersion := "3.1.8"
 			}
 
 			if *infoMetric == true {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func runStats(config config.Config) {
 			status := statusCodeMap[item.Info.Status.String()]
 			latestVersion := ""
 
-			if *latestVersion {
+			if *fetchLatest {
 				latestVersion = getLatestChartVersionFromHelm(item.Chart.Name(), config.HelmRegistries)
 				//latestVersion := "3.1.8"
 			}

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	"github.com/sstarcher/helm-exporter/config"
-	"github.com/sstarcher/helm-exporter/registries"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/sstarcher/helm-exporter/config"
+	"github.com/sstarcher/helm-exporter/registries"
 
 	cmap "github.com/orcaman/concurrent-map"
 
@@ -67,6 +68,8 @@ var (
 	infoMetric      = flag.Bool("info-metric", true, "Generate info metric.  Defaults to true")
 	timestampMetric = flag.Bool("timestamp-metric", true, "Generate timestamps metric.  Defaults to true")
 
+	fetchLatest = flag.Bool("latest-chart-version", true, "Attempt to fetch the latest chart version from registries. Defaults to true")
+
 	statusCodeMap = map[string]float64{
 		"unknown":          0,
 		"deployed":         1,
@@ -112,8 +115,12 @@ func runStats(config config.Config) {
 			updated := item.Info.LastDeployed.Unix() * 1000
 			namespace := item.Namespace
 			status := statusCodeMap[item.Info.Status.String()]
-			latestVersion := getLatestChartVersionFromHelm(item.Chart.Name(), config.HelmRegistries)
-			//latestVersion := "3.1.8"
+			latestVersion := ""
+
+			if *latestVersion {
+				latestVersion = getLatestChartVersionFromHelm(item.Chart.Name(), config.HelmRegistries)
+				//latestVersion := "3.1.8"
+			}
 
 			if *infoMetric == true {
 				statsInfo.WithLabelValues(chart, releaseName, version, appVersion, strconv.FormatInt(updated, 10), namespace, latestVersion).Set(status)
@@ -127,7 +134,7 @@ func runStats(config config.Config) {
 
 func getLatestChartVersionFromHelm(name string, helmRegistries registries.HelmRegistries) (version string) {
 	version = helmRegistries.GetLatestVersionFromHelm(name)
-	log.Warnf("last chart repo version is  %v", version)
+	log.WithField("chart", name).Debugf("last chart repo version is  %v", version)
 	return
 }
 


### PR DESCRIPTION
Fetching all upstream latest chart versions can be problematic in large cluster deploys. The feature is also less helpful in its current from when using a large number of private charts/repositories. 