### PR TITLE
Execute runStats in background to avoid timeout when done synchronously

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/target/go-arty v0.0.0-20191122155631-9967a6326524 h1:xh2u1ZzUdMn9rDI6CmKnPVmi4rijmJCOKYjjZnSVWEY=


### PR DESCRIPTION
We have an issue in our cluster with around 100 releases: the exporter takes too long to compute metrics on the fly (around 15 to 20 seconds) which is above the 10s timeout of prometheus.

I propose to fetch data from the cluster in the background, every 30 seconds, to void computing them on the fly and expose current metrics values on the `/metrics` endpoint.

It uses mutex to properly switch data (the beginning of `runStats` is a `Reset` so if metrics request come in the middle of the refresh, it's broken).

The only drawback when used without the `namespace` flag: during the first 30s there is no data (the `go informer()` has not yet finished but the `runStats` starts...) It's only the first 30s on cold start, I think it's ok. Let me know what you think about it.

# Results

Before the change, on a test cluster (55 releases):

```
> time curl http://localhost:9571/metrics

real    0m4.444s
user    0m0.012s
sys     0m0.013s
```

After the change,

```
real    0m0.033s
user    0m0.013s
sys     0m0.013s
```