### PR TITLE
Allow for podLabels to be set

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         {{- include "helm-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 podAnnotations: {}
+podLabels: {}
 
 env: []
   # e.g. no_proxy environment variable:


### PR DESCRIPTION
Hello,

there are cases when you want to explicitly set additional podLabels without introducing any changes to already managed resources (selectorLabels).