### PR TITLE
Address changes to artifacthub API

### DIFF
--- a/registries/helm_hub.go
+++ b/registries/helm_hub.go
@@ -11,18 +11,13 @@ import (
 
 var errMultipleCharts = errors.New("multiple charts found")
 
-// Charts is data structure coming from hub.helm.sh
-type Charts struct {
-	Data []Chart `json:"data"`
-}
-
-// Chart contains attribute information for a chart coming from hub.helm.sh
+// Chart contains attribute information for a chart
 type Chart struct {
-	Attributes Attributes `json:"attributes"`
+	AvailableVersions []AvailableVersions `json:"available_versions"`
 }
 
-// Attributes contains version information for a chart coming from hub.helm.sh
-type Attributes struct {
+// AvailableVersions contains list of versions for a chart
+type AvailableVersions struct {
 	Version string `json:"version"`
 }
 
@@ -85,7 +80,7 @@ func findChart(chart string) (string, error) {
 }
 
 func getChartVersions(chart string) ([]string, error) {
-	url := fmt.Sprintf("https://hub.helm.sh/api/chartsvc/v1/charts/%s/versions", chart)
+	url := fmt.Sprintf("https://artifacthub.io/api/v1/packages/helm/%s", chart)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -93,15 +88,15 @@ func getChartVersions(chart string) ([]string, error) {
 
 	defer resp.Body.Close()
 
-	chartsData := Charts{}
-	err = json.NewDecoder(resp.Body).Decode(&chartsData)
+	chartData := Chart{}
+	err = json.NewDecoder(resp.Body).Decode(&chartData)
 	if err != nil {
 		return nil, err
 	}
 
 	var versions []string
-	for _, data := range chartsData.Data {
-		versions = append(versions, data.Attributes.Version)
+	for _, data := range chartData.AvailableVersions {
+		versions = append(versions, data.Version)
 	}
 	return versions, nil
 }


### PR DESCRIPTION
The HTTP request in `getChartVersions` redirects to `https://artifacthub.io/api/chartsvc/v1/charts/%s` which doesn't return a JSON structure and instead returns a 200 with a HTML response causing a [parsing error](https://github.com/sstarcher/helm-exporter/issues/56).

Based on the Artifact Hub API [documentation](https://artifacthub.github.io/hub/api/?urls.primaryName=Artifact%20Hub%20API) this PR updates the request URL and also the parses the new JSON response structure.

Note: the HTTP request in `findChart` results in a redirect to `https://artifacthub.io/api/chartsvc/v1/charts/search?q=%s` which is still a valid [API](https://artifacthub.github.io/hub/api/?urls.primaryName=Monocular%20compatible%20search%20API#/Monocular/get_api_chartsvc_v1_charts_search)