### PR TITLE
Optimize test-connection

### DIFF
--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -6,10 +6,11 @@ metadata:
 {{ include "helm-exporter.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   containers:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "helm-exporter.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ include "helm-exporter.fullname" . }}:{{ .Values.service.port }}/healthz']
   restartPolicy: Never


### PR DESCRIPTION
This sets the test to connect to correct /healthz endpoint, resulting in a HTTP 200 OK response code and will mark the test as successful.

Added hook hook-delete-policy to remove/cleanup the test pod if the test is successful (so subsequent test run won't encounter the error `warning: Hook test helm-exporter/templates/tests/test-connection.yaml failed: pods "helm-exporter-test-connection" already exists`

Fixes https://github.com/sstarcher/helm-exporter/issues/58