### PR TITLE
Added support for custom service scrape-enable annotation

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the helm-exporter chart
 | securityContext | object | `{}` | SecurityContext for a container |
 | service.port | int | `9571` | Port for Service to listen on. |
 | service.type | string | `"ClusterIP"` | Service type |
+| service.customScrapeEnableAnnotation | string | `""` | Custom annotation to enable scraping. If empty, `prometheus.io/scrape: "true"` will be used |
 | serviceAccount.create | bool | `true` | Create a default serviceaccount to use |
 | serviceAccount.name | string | `default` | Name for prometheus serviceaccount |
 | serviceMonitor.create | bool | `false` | Set to true if using the Prometheus Operator |

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "helm-exporter.labels" . | nindent 4 }}
   annotations:
   {{- if not .Values.serviceMonitor.create }}
-    prometheus.io/scrape: "true"
+    {{ .Values.service.customScrapeEnableAnnotation | default "prometheus.io/scrape: \"true\"" }}
   {{- end }}
   {{- if .Values.service.annotations }}
 {{ .Values.service.annotations | toYaml | indent 4}}


### PR DESCRIPTION
Fixes #62.  Allows custom replacement for `prometheus.io/scrape: "true"` annotation.