### PR TITLE
Add agent for request to artifacthub.io/api/chartsvc

### DIFF
--- a/registries/helm_hub.go
+++ b/registries/helm_hub.go
@@ -60,9 +60,9 @@ func findChart(chart string) (string, error) {
 	url := fmt.Sprintf("https://artifacthub.io/api/chartsvc/v1/charts/search?q=%s", chart)
 
 	client := &http.Client{}
-  req, err := http.NewRequest("GET", url, nil)
-  req.Header.Set("User-Agent", "Go-http-client/1.1")
-  resp, err := client.Do(req)
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("User-Agent", "Go-http-client/1.1")
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return "", err
@@ -86,7 +86,7 @@ func findChart(chart string) (string, error) {
 
 func getChartVersions(chart string) ([]string, error) {
 	url := fmt.Sprintf("https://artifacthub.io/api/v1/packages/helm/%s", chart)
-  resp, err := http.Get(url)
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/registries/helm_hub.go
+++ b/registries/helm_hub.go
@@ -57,8 +57,13 @@ func (h HelmRegistries) useHelmHub(chart string) string {
 }
 
 func findChart(chart string) (string, error) {
-	url := fmt.Sprintf("https://hub.helm.sh/api/chartsvc/v1/charts/search?q=%s", chart)
-	resp, err := http.Get(url)
+	url := fmt.Sprintf("https://artifacthub.io/api/chartsvc/v1/charts/search?q=%s", chart)
+
+	client := &http.Client{}
+  req, err := http.NewRequest("GET", url, nil)
+  req.Header.Set("User-Agent", "Go-http-client/1.1")
+  resp, err := client.Do(req)
+
 	if err != nil {
 		return "", err
 	}
@@ -81,7 +86,7 @@ func findChart(chart string) (string, error) {
 
 func getChartVersions(chart string) ([]string, error) {
 	url := fmt.Sprintf("https://artifacthub.io/api/v1/packages/helm/%s", chart)
-	resp, err := http.Get(url)
+  resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the URL from hub.helm.sh to artifacthub.io so we can skip the redirection

Add the agent to fix https://github.com/sstarcher/helm-exporter/issues/64

It seems only this endpoint requires a user agent.