### PR TITLE
Update ingress to suit networking.k8s.io/v1

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -29,6 +29,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -30,8 +30,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
I believe the latest versions of the chart are broken (1.1.0 and 1.0.1 both seem affected) due to `backend` in the ingress not matching the `networking.k8s.io/v1` API spec; I've been receiving the following error on creating a release:

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]
```

 See https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource and https://blog.hycorve.com/migrating-from-ingress-networking-k8s-io-v1beta1-to-v1/
 
 I can't tell how you handle chart versioning here since the Chart.yaml hasn't been updated in 2 years, so I assume this is automated. 