### PR TITLE
Make deployment probes configurable

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -40,6 +40,7 @@ Exporter for helm metrics
 | ingress.tls                                        | list   | `[]`                        |                                                                |
 | intervalDuration                                   | int    | `0`                         |                                                                |
 | latestChartVersion                                 | bool   | `true`                      |                                                                |
+| livenessProbe                                      | object | (see `values.yaml`)         |  Liveness probe configuration                                  |
 | nameOverride                                       | string | `""`                        |                                                                |
 | namespaces                                         | string | `""`                        |                                                                |
 | nodeSelector                                       | object | `{}`                        |                                                                |
@@ -47,6 +48,7 @@ Exporter for helm metrics
 | podLabels                                          | object | `{}`                        |                                                                |
 | podSecurityContext                                 | object | `{}`                        |                                                                |
 | rbac.create                                        | bool   | `true`                      |                                                                |
+| readinessProbe                                     | object | (see `values.yaml`)         |  Readiness probe configuration                                 |
 | replicaCount                                       | int    | `1`                         |                                                                |
 | resources                                          | object | `{}`                        |                                                                |
 | securityContext                                    | object | `{}`                        |                                                                |
@@ -60,6 +62,7 @@ Exporter for helm metrics
 | serviceMonitor.interval                            | string | `nil`                       |                                                                |
 | serviceMonitor.namespace                           | string | `nil`                       |                                                                |
 | serviceMonitor.scrapeTimeout                       | string | `nil`                       |                                                                |
+| startupProbe                                       | object | (see `values.yaml`)         |  Startup probe configuration                                   |
 | timestampMetric                                    | bool   | `true`                      |                                                                |
 | tolerations                                        | list   | `[]`                        |                                                                |
 | grafanaDashboard.enabled                           | bool   | `false`                     | Specifies whether a Grafana dashboard should be created        |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -75,13 +75,11 @@ spec:
               containerPort: 9571
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.config }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.serviceMonitor.create }}
+{{ if and .Values.serviceMonitor.create (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,6 +33,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# Startup probe configuration
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
 rbac:
   create: true
 


### PR DESCRIPTION
helm-exporter might be slow to start on clusters with a relatively large number of namespaces, that might cause a crashloop. Custom probe configuration totally fixes it.