### PR TITLE
disable update artifacthub cache when fetchLatest is false

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver"
 
 	"github.com/sstarcher/helm-exporter/config"
+	"github.com/sstarcher/helm-exporter/registries"
 
 	cmap "github.com/orcaman/concurrent-map"
 
@@ -297,6 +298,9 @@ func main() {
 	}
 
 	config := config.New(*configFile)
+	if *fetchLatest {
+		registries.Update()
+	}
 	runIntervalDuration, err := time.ParseDuration(*intervalDuration)
 	if err != nil {
 		log.Fatalf("invalid duration `%s`: %s", *intervalDuration, err)

--- a/registries/helm_hub.go
+++ b/registries/helm_hub.go
@@ -56,7 +56,7 @@ func httpGet(endpoint string, data interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(data)
 }
 
-func init() {
+func Update() {
 	err := update()
 	if err != nil {
 		log.Warnf("failed to update artifacthub cache due to %v ", err)


### PR DESCRIPTION
When fetchLatest is false, we don't need the background job to update artifacthub cache every hour.