### PR TITLE
Added Release status as a label to the metric

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
             {{- if not .Values.latestChartVersion }}
             - "-latest-chart-version=false"
             {{- end }}
+            {{- if .Values.statusInMetric }}
+            - "-status-in-metric=true"
+            {{- end }}
             {{- with .Values.intervalDuration }}
             - "-interval-duration={{ . }}"
             {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,7 @@ namespacesIgnore: ""
 infoMetric: true
 timestampMetric: true
 latestChartVersion: true
+statusInMetric: false
 intervalDuration: 0
 
 serviceMonitor:


### PR DESCRIPTION
Added release status as a string to the metric as additional label.
This addition was needed because with the current implementation, the encoded status as value, it's nearly impossible and extremely complicated (at least for me with my knowledge on Grafana and PromQL) to be able to count and breakdown by the status of the Helm charts.
With this addition we are able to have clear overview of the state of our Helm releases and visualize them in Grafana. 
![grafana-dashboard-screenshot ](https://user-images.githubusercontent.com/15233365/185141633-a14cbd1b-7143-4301-b35c-71f8124c492f.png)

Our idea was to be notified if we have a release which is stuck in a "bad" state for a certain time and now we're able to to do it.
I think the resource footprint on Prometheus would be really negligible since this label has really low (predefined) cardinality.
