### PR TITLE
Add bool conditions

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,23 +232,30 @@ func registerMetrics(register prometheus.Registerer, info, timestamp *prometheus
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	if statsInfo != nil {
-		register.Unregister(statsInfo)
+	if *infoMetric == true {
+		if statsInfo != nil {
+			register.Unregister(statsInfo)
+		}
+		register.MustRegister(info)
+		statsInfo = info
 	}
-	register.MustRegister(info)
-	statsInfo = info
 
-	if statsTimestamp != nil {
-		register.Unregister(statsTimestamp)
+	if *timestampMetric == true {
+		if statsTimestamp != nil {
+			register.Unregister(statsTimestamp)
+		}
+		register.MustRegister(timestamp)
+		statsTimestamp = timestamp
 	}
-	register.MustRegister(timestamp)
-	statsTimestamp = timestamp
 
-	if statsOutdated != nil {
-		register.Unregister(statsOutdated)
+	if *outdatedMetric == true {
+		if statsOutdated != nil {
+			register.Unregister(statsOutdated)
+		}
+		register.MustRegister(outdated)
+		statsOutdated = outdated
 	}
-	register.MustRegister(outdated)
-	statsOutdated = outdated
+
 }
 
 func newHelmStatsHandler(config config.Config, synchrone bool) http.HandlerFunc {


### PR DESCRIPTION
It should fix the problem when you do not need to enable all types of metrics.
Without it if you disable one of **"info-metric"|"timestamp-metric"|"outdated-metric"**
you will get this error.
`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103d77460]
`
Thanks!
