### PR TITLE
fix: wait for the clients before starting to collect metrics when using the interval-duration option

### DIFF
--- a/main.go
+++ b/main.go
@@ -365,6 +365,16 @@ func main() {
 	}
 
 	if runIntervalDuration != 0 {
+		// wait for the clients to be found, before the initial start of collecting metrics
+		var previousClientsCount int
+		for {
+			currentClientsCount := clients.Count()
+			if previousClientsCount == currentClientsCount && currentClientsCount > 0 {
+				break
+			}
+			previousClientsCount = currentClientsCount
+			time.Sleep(5 * time.Second)
+		}
 		go runStatsPeriodically(runIntervalDuration, config)
 	} else {
 		info, timestamp, outdated := configureMetrics()


### PR DESCRIPTION
Thanks for the exporter :)
We are going to change to way how we collect metrics by using the `interval-duration` set more or less every few hours. Unfortunately for the initial metrics, we have to wait for `interval-duration`, because there are no `clients` collected at the initial run stats.