### PR TITLE
Fix to get all releases statuses and not only deployed/failed (default)

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,8 @@ func runStats(config config.Config, info *prometheus.GaugeVec, timestamp *promet
 
 	for _, client := range clients.Items() {
 		list := action.NewList(client.(*action.Configuration))
+		list.All = true
+		list.SetStateMask()
 		items, err := list.Run()
 		if err != nil {
 			log.Warnf("got error while listing %v", err)


### PR DESCRIPTION
By default, like "helm list", only deployed and failed statuses are returned. If you want all releases statuses, like "helm list --all", you need this fix.

 #117