### PR TITLE
pins alpine version to latest 3.18.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /go/src/github.com/sstarcher/helm-exporter
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /go/bin/helm-exporter /go/src/github.com/sstarcher/helm-exporter/main.go
 
-FROM alpine:3
+FROM alpine:3.18.3
 RUN apk --update add ca-certificates
 RUN addgroup -S helm-exporter && adduser -S -G helm-exporter helm-exporter
 USER helm-exporter


### PR DESCRIPTION
Currently the latest docker image of helm-exporter is built with alpine 3.18.2 which has multiple critical security vulnerabilities (busybox, ssl_client). Pinning the alpine version to the latest 3.18 release fixes those vulnerabilities