### PR TITLE
Set the Deployment namespace from {{ .Release.Namespace }}

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "helm-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "helm-exporter.labels" . | nindent 4 }}
   {{- with .Values.annotations }}


### PR DESCRIPTION
The namespace of the deployment should be explicitly set from the release namespace.

Without this, you are reliant on the helm caller (and may end up in a default namespace). A recent issue in terraform-provider-helm (https://github.com/hashicorp/terraform-provider-helm/issues/1646) highlights how this can be problematic.