### PR TITLE
Expose helm history as prometheus gauge

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             {{- if not .Values.infoMetric }}
             - "-info-metric=false"
             {{- end }}
+            {{- if .Values.historyMetric }}
+            - "-history-metric=true"
+            {{- end }}
             {{- if not .Values.timestampMetric }}
             - "-timestamp-metric=false"
             {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,6 +3,7 @@ namespaces: ""
 # you can specify namespaces to ignore - comma separated list of regexps
 namespacesIgnore: ""
 infoMetric: true
+historyMetric: false
 timestampMetric: true
 latestChartVersion: true
 statusInMetric: false


### PR DESCRIPTION
Helm exporter is able to extract a history of releases been installed in cluster. It is useful sometimes to visualize release history in Grafana. The suggestion is to optionally query helm history by all installed releases and use dedicated gauge to export this metric.