### PR TITLE
Update Go version to 1.24 in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.20'
+        go-version: '1.24'
       id: go
 
     - uses: actions/checkout@v4


### PR DESCRIPTION
Needed for #186 