### PR TITLE
Support setting log level in helm

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -41,6 +41,7 @@ Exporter for helm metrics
 | intervalDuration                                   | int    | `0`                         |                                                                |
 | latestChartVersion                                 | bool   | `true`                      |                                                                |
 | livenessProbe                                      | object | (see `values.yaml`)         |  Liveness probe configuration                                  |
+| logLevel                                           | string | `"error"`                   |  Set log level (info,warning,error,debug)                      |
 | nameOverride                                       | string | `""`                        |                                                                |
 | namespaces                                         | string | `""`                        |                                                                |
 | nodeSelector                                       | object | `{}`                        |                                                                |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
             {{- with .Values.intervalDuration }}
             - "-interval-duration={{ . }}"
             {{- end }}
+            {{- with .Values.logLevel }}
+            - "-log-level={{ . }}"
+            {{- end }}
           {{- if .Values.env }}
           env:
 {{ toYaml .Values.env | indent 12}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,7 @@ timestampMetric: true
 latestChartVersion: true
 statusInMetric: false
 intervalDuration: 0
+logLevel: "error"
 
 serviceMonitor:
   # Specifies whether a ServiceMonitor should be created


### PR DESCRIPTION
To make debugging a bit easier,  add support to set the log level of the pod in the helm deployment. Otherwise you must manually set this in the deployment each time