### PR TITLE
Fix when securitycontext is enabled

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: {{ include "helm-exporter.fullname" . }}
+            - mountPath: /.cache
+              name: cache
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -114,4 +116,6 @@ spec:
       - name: {{ include "helm-exporter.fullname" . }}
         configMap:
           name: {{ include "helm-exporter.fullname" . }}
+      - name: cache
+        emptyDir: {}
     {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,7 +27,7 @@ grafanaDashboard:
   # namespace:
   # Add annotations to Configmap for Grafana dashboard
   dashboardAnnotations: {}
-    # k8s-sidecar-target-directory: /tmp/dashboards/myfolder  
+    # k8s-sidecar-target-directory: /tmp/dashboards/myfolder
 
 replicaCount: 1
 
@@ -81,9 +81,12 @@ env: []
   #   value: localhost
 
 securityContext: {}
+  # allowPrivilegeEscalation: false
+  # seccompProfile:
+  #   type: RuntimeDefault
   # capabilities:
   #   drop:
-  #   - ALL
+  #     - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000


### PR DESCRIPTION
Hi,

just started using your exporter and noticed that when you enable securityContexts, especially readOnlyRootFilesystem: true, the exporter won't work with custom helm repos. Because it needs to download file to /.cache. So I made this folder an emptyDir to make it work !

Also I updated the "exemple" securityContext in the values file to be inline with the restricted PSS : [https://kubernetes.io/docs/concepts/security/pod-security-standards/#privileged](https://kubernetes.io/docs/concepts/security/pod-security-standards/#privileged)

