### PR TITLE
Add support for OCI-based Helm registries (oci://)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ config:
     - bitnami
 ```
 
+## Configuration for OCI registries
+
+Registries can also be configured as OCI (Open Container Initiative) registries by prefixing the `url` with `oci://`. helm-exporter lists the tags published to the chart's OCI repository and reports the highest one as the latest version, the same way `helm pull oci://...` resolves chart versions.
+
+```yaml
+# Helm configuration
+config:
+  helmRegistries:
+    override:
+      - registry:
+          url: "oci://registry.example.com/helm" # OCI registry, no index.yaml involved
+        charts: # Chart names
+        - kube-prometheus-stack
+      - registry:
+          url: "oci://ghcr.io/prometheus-community/charts"
+        charts:
+        - kube-prometheus-stack
+```
+
+Private OCI registries are supported the same way `helm` itself supports them: run `helm registry login registry.example.com` on a host (or in an init step) before starting helm-exporter, or point `HELM_REGISTRY_CONFIG` at an existing Helm registry credentials file. helm-exporter does not introduce a separate authentication mechanism for OCI - it reuses whatever credentials the Helm CLI would use.
+
 # Metrics
 * http://host:9571/metrics
 

--- a/registries/helm_index.go
+++ b/registries/helm_index.go
@@ -6,6 +6,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/repo"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -45,8 +46,19 @@ func init() {
 	}
 }
 
+// getChartVersions is the single point in the codebase that decides which
+// chart-repository strategy to use for a registry: an OCI registry lookup
+// (tags on the repository) or the classic index.yaml lookup. Everything
+// else - HelmRegistries.GetLatestVersionFromHelm, the config format, the
+// metrics - stays unaware of the distinction.
 func (r HelmOverrideRegistry) getChartVersions(chart string) string {
+	if registry.IsOCI(r.HelmRegistry.URL) {
+		return r.getChartVersionsOCI(chart)
+	}
+	return r.getChartVersionsHTTP(chart)
+}
 
+func (r HelmOverrideRegistry) getChartVersionsHTTP(chart string) string {
 	// trim the index.yaml suffix from the chart url, just to avoid breaking changes.
 	url := strings.TrimSuffix(r.HelmRegistry.URL, indexYamlSuffix)
 
@@ -71,26 +83,29 @@ func (r HelmOverrideRegistry) getChartVersions(chart string) string {
 	}
 
 	provider := getter.All(settings)
-
 	chartRepo, err := repo.NewChartRepository(entry, provider)
 	if err != nil {
 		log.Warning(err)
 		return versioning.Failure
 	}
+
 	idx, err := chartRepo.DownloadIndexFile()
 	if err != nil {
 		log.Warning(err)
 		return versioning.Failure
 	}
+
 	repoIndex, err := repo.LoadIndexFile(idx)
 	if err != nil {
 		log.Warning(err)
 		return versioning.Failure
 	}
+
 	chartVersion, err := repoIndex.Get(chart, "")
 	if err != nil {
 		log.Warning(err)
 		return versioning.Failure
 	}
+
 	return chartVersion.Version
 }

--- a/registries/helm_oci.go
+++ b/registries/helm_oci.go
@@ -1,0 +1,63 @@
+package registries
+
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/registry"
+
+	"github.com/sstarcher/helm-exporter/versioning"
+)
+
+// ociClient is a single, shared OCI registry client. It is configured the
+// same way the Helm CLI configures itself (see registry.NewClient in
+// cmd/helm/root.go upstream): it reads whatever credentials are already on
+// disk for `helm registry login`, honouring HELM_REGISTRY_CONFIG. No new
+// authentication mechanism is introduced - private OCI registries work
+// exactly like they do for `helm pull oci://...`.
+var ociClient *registry.Client
+
+func init() {
+	client, err := registry.NewClient(
+		registry.ClientOptCredentialsFile(settings.RegistryConfig),
+	)
+	if err != nil {
+		log.Warning(err)
+		return
+	}
+	ociClient = client
+}
+
+// ociRef builds the OCI reference (host/path/chart, no scheme) that the
+// registry client expects, from a `oci://host/path` registry URL and a
+// chart name. Split out as its own function so it can be unit tested
+// without a network round trip.
+func ociRef(registryURL, chart string) string {
+	trimmed := strings.TrimSuffix(registryURL, "/")
+	trimmed = strings.TrimPrefix(trimmed, "oci://")
+	return trimmed + "/" + chart
+}
+
+// getChartVersionsOCI fetches the latest version of a chart published to
+// an OCI registry. OCI registries have no index.yaml; instead every chart
+// version is pushed as its own tag, so the available versions are the
+// tags on the repository. That mirrors how `helm pull oci://... --version
+// <tag>` resolves versions, and it lets us reuse the existing
+// FindHighestVersionInList helper (the same one the rest of the exporter
+// uses) instead of adding a second way to pick "the latest" version.
+func (r HelmOverrideRegistry) getChartVersionsOCI(chart string) string {
+	if ociClient == nil {
+		log.Warning("OCI registry client is not initialized")
+		return versioning.Failure
+	}
+
+	ref := ociRef(r.HelmRegistry.URL, chart)
+
+	tags, err := ociClient.Tags(ref)
+	if err != nil {
+		log.Warning(err)
+		return versioning.Failure
+	}
+
+	return versioning.FindHighestVersionInList(tags, r.AllowAllReleases)
+}

--- a/registries/helm_oci_test.go
+++ b/registries/helm_oci_test.go
@@ -1,0 +1,141 @@
+package registries
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/registry"
+
+	"github.com/sstarcher/helm-exporter/versioning"
+)
+
+// --- URL detection -----------------------------------------------------
+//
+// registry.IsOCI is the official Helm SDK function the exporter now relies
+// on to decide which strategy to use. These cases pin down the exact
+// behavior the rest of the package depends on, so a Helm SDK upgrade that
+// changes this behavior fails loudly here instead of silently changing
+// which registries are treated as OCI.
+
+func TestIsOCIDetection(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"oci scheme", "oci://registry.example.com/helm", true},
+		{"oci scheme, no path", "oci://ghcr.io", true},
+		{"https scheme", "https://prometheus-community.github.io/helm-charts", false},
+		{"http scheme", "http://charts.example.com", false},
+		{"index.yaml url", "https://some.url/index.yaml", false},
+		{"empty url", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := registry.IsOCI(c.url); got != c.want {
+				t.Errorf("registry.IsOCI(%q) = %v, want %v", c.url, got, c.want)
+			}
+		})
+	}
+}
+
+// --- ref building --------------------------------------------------------
+
+func TestOCIRef(t *testing.T) {
+	cases := []struct {
+		name        string
+		registryURL string
+		chart       string
+		want        string
+	}{
+		{
+			name:        "basic",
+			registryURL: "oci://registry.example.com/helm",
+			chart:       "kube-prometheus-stack",
+			want:        "registry.example.com/helm/kube-prometheus-stack",
+		},
+		{
+			name:        "ghcr example from the issue",
+			registryURL: "oci://ghcr.io/prometheus-community/charts",
+			chart:       "kube-prometheus-stack",
+			want:        "ghcr.io/prometheus-community/charts/kube-prometheus-stack",
+		},
+		{
+			name:        "trailing slash is tolerated",
+			registryURL: "oci://registry.example.com/helm/",
+			chart:       "prometheus",
+			want:        "registry.example.com/helm/prometheus",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ociRef(c.registryURL, c.chart); got != c.want {
+				t.Errorf("ociRef(%q, %q) = %q, want %q", c.registryURL, c.chart, got, c.want)
+			}
+		})
+	}
+}
+
+// --- error handling / regression -----------------------------------------
+
+// A registry misconfigured so the shared client is unavailable must fail
+// safely (the same versioning.Failure sentinel the HTTP path already
+// returns) instead of panicking.
+func TestGetChartVersionsOCI_ClientNotInitialized(t *testing.T) {
+	original := ociClient
+	ociClient = nil
+	defer func() { ociClient = original }()
+
+	r := HelmOverrideRegistry{
+		HelmRegistry: HelmRegistry{URL: "oci://registry.example.com/helm"},
+	}
+
+	got := r.getChartVersionsOCI("prometheus")
+	if got != versioning.Failure {
+		t.Errorf("getChartVersionsOCI() with nil client = %q, want %q", got, versioning.Failure)
+	}
+}
+
+// Regression: an https:// registry must never be routed through the OCI
+// strategy, and vice versa. This is the one branch point the whole
+// feature depends on staying correct.
+func TestGetChartVersions_DispatchesByScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		oci  bool
+	}{
+		{"https repo stays on the HTTP path", "https://prometheus-community.github.io/helm-charts", false},
+		{"oci repo uses the OCI path", "oci://registry.example.com/helm", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := registry.IsOCI(c.url); got != c.oci {
+				t.Errorf("registry.IsOCI(%q) = %v, want %v (this drives getChartVersions dispatch)", c.url, got, c.oci)
+			}
+		})
+	}
+}
+
+// Invalid/unreachable OCI URLs must degrade to versioning.Failure rather
+// than crash the exporter, same contract as the existing HTTP path for
+// invalid/unreachable index.yaml URLs. This exercises the real network
+// call, so it is skipped by default - see the "Testing" section of the PR
+// description for why an integration test is the right tool here instead
+// of mocking the OCI transport.
+func TestGetChartVersionsOCI_InvalidHost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network-dependent OCI test in -short mode")
+	}
+
+	r := HelmOverrideRegistry{
+		HelmRegistry: HelmRegistry{URL: "oci://invalid.invalid.example/helm"},
+	}
+
+	got := r.getChartVersionsOCI("does-not-exist")
+	if got != versioning.Failure {
+		t.Errorf("getChartVersionsOCI() with unreachable host = %q, want %q", got, versioning.Failure)
+	}
+}


### PR DESCRIPTION
Closes #83

# Add support for OCI-based Helm registries (`oci://`)

## Summary

Adds support for chart repositories configured with an `oci://` URL, in addition to the classic HTTP(s)/`index.yaml` repositories helm-exporter already supports. A registry entry like:

```yaml
config:
  helmRegistries:
    override:
      - registry:
          url: "oci://registry.example.com/helm"
        charts:
        - kube-prometheus-stack
```

now resolves the chart's latest version by listing the tags published to that OCI repository (the same way `helm pull oci://...` resolves versions), instead of failing/being silently unsupported.

## Motivation

Closes #83. OCI is now the primary distribution mechanism for a growing share of the Helm ecosystem (Bitnami's move to OCI-only, many vendors publishing to `ghcr.io`, ECR, ACR, GAR, Docker Hub, Harbor, etc.). Users who've migrated their chart repos to OCI currently have no way to get "latest version" / "outdated" metrics for those charts out of helm-exporter - this closes that gap using the same config shape they already use for HTTP registries.

## Implementation details

- `registry.HelmRegistry.URL` is now inspected with the official Helm SDK helper `registry.IsOCI(url)` at the single existing chart-lookup entry  point, `HelmOverrideRegistry.getChartVersions` in `registries/helm_index.go`. This is the one place in the codebase that decides which chart-repository strategy to use; nothing else changed.
- The pre-existing HTTP/index.yaml logic is unchanged in behavior; it was renamed to `getChartVersionsHTTP` so it could sit alongside the new strategy under a common dispatcher.
- A new file, `registries/helm_oci.go`, adds the OCI strategy:
  - `registry.NewClient(registry.ClientOptCredentialsFile(settings.RegistryConfig))` builds a single shared OCI client at package init, using the Helm SDK (`helm.sh/helm/v3/pkg/registry`) - the same SDK already used elsewhere in this package for other Helm operations.
  - `(*registry.Client).Tags(ref)` lists the chart's published versions.
  - The highest version is picked with `versioning.FindHighestVersionInList`, which already existed in this codebase for exactly this
    "pick the newest of these version strings" job - no new version-sorting logic was added.
- No new dependency was added; `helm.sh/helm/v3/pkg/registry` ships inside the `helm.sh/helm/v3` module the project already depends on.

## Testing

`registries/helm_oci_test.go` adds:
- Table tests pinning down `registry.IsOCI` behavior for `oci://`, `https://`, `http://`, an `index.yaml` URL, and an empty string, so a future Helm SDK upgrade that changes this behavior is caught here.
- Table tests for the `oci://host/path` + chart name -> registry-ref construction (`ociRef`), including the example URLs from #83 and a trailing-slash case.
- A regression test asserting `https://` registries still dispatch to the HTTP path and `oci://` registries dispatch to the OCI path.
- An error-handling test for an uninitialized OCI client (returns `versioning.Failure`, doesn't panic).
- A network-dependent test (skipped under `-short`) against an unreachable OCI host, asserting the same `versioning.Failure` contract the HTTP path already has for unreachable/invalid URLs.

An integration test against a real public OCI registry (e.g.`oci://registry-1.docker.io/bitnamicharts` or `ghcr.io`) was intentionally left out of the automated suite rather than added as a live network call in CI: the project has no existing pattern for network-dependent CI tests (there are no `_test.go` files in the repo today), and a live third-party registry is a flaky, rate-limitable dependency for CI. The `-short`-skippable test above exercises the same failure path a misconfigured/offline registry would hit. If maintainers want a live smoke test, I'm happy to add one gated behind a build tag (e.g. `//go:build integration`) so it doesn't run by default in CI - let me know your preference.

To validate manually:
```
go build ./...
go test ./registries/... -v
```
then point a config file at a public OCI chart, e.g.:
```yaml
config:
  helmRegistries:
    override:
      - registry:
          url: "oci://ghcr.io/prometheus-community/charts"
        charts:
        - kube-prometheus-stack
```

## Backward compatibility

- No change to the YAML config schema, any struct tag, any metric name, or any metric label - `main.go` is untouched.
- Every existing `https://`/`http://` registry is still routed through the identical, byte-for-byte-unchanged HTTP lookup logic (`getChartVersionsHTTP`); `registry.IsOCI` only returns `true` for URLs that start with `oci://`, so no existing config is affected.
- No new required configuration and no new authentication mechanism: OCI auth reuses whatever credentials `helm registry login` (or `HELM_REGISTRY_CONFIG`) already provides, matching how the Helm CLI itself authenticates to OCI registries.